### PR TITLE
ask_fandom: fallback to AnswersWikiIntent

### DIFF
--- a/INTENTS.md
+++ b/INTENTS.md
@@ -22,3 +22,9 @@ This file documents all available intents that can answer various types of quest
 
 * _Which club Cristiano Ronaldo plays for?_
 * _Where is Lionel Messi playing now?_
+
+## `AnswersWikiIntent`
+> Provides answers using Answers wiki
+
+* _Do I need a passport to travel to Italy?_
+* _What are faxes used for?_

--- a/ask.py
+++ b/ask.py
@@ -15,19 +15,19 @@ from ask_fandom.intents.selector import get_intent
 def ask_fandom(question: str):
     """
     :type question str
-    :rtype: ask_fandom.intents.base.Answer
+    :rtype: tuple[ask_fandom.intents.base, ask_fandom.intents.base.Answer]
     """
     try:
-        (intent_class, intent_args, _) = get_intent(question)
+        (intent_class, intent_args, words) = get_intent(question)
         intent = intent_class(question, **intent_args)
 
-        return intent.get_answer()
+        return intent, words, intent.get_answer()
 
     except AskFandomError as ex:
         try:
             # fall back to Q&A wiki site for an answer
             # TODO: fully index questions and answers and extract knowledge from them
-            return AnswersWikiIntent(question).get_answer()
+            return AnswersWikiIntent, None, AnswersWikiIntent(question).get_answer()
 
         except AskFandomError:
             # return the original exception

--- a/ask.py
+++ b/ask.py
@@ -8,6 +8,7 @@ from os import getenv
 from sys import argv
 
 from ask_fandom.errors import AskFandomError
+from ask_fandom.intents import AnswersWikiIntent  # a temporary fallback for ask_fandom
 from ask_fandom.intents.selector import get_intent
 
 
@@ -23,10 +24,14 @@ def ask_fandom(question: str):
         return intent.get_answer()
 
     except AskFandomError as ex:
-        # fall back to Q&A Wikia site for an answer
-        # TODO: fully index questions and answers and extract knowledge from them
+        try:
+            # fall back to Q&A wiki site for an answer
+            # TODO: fully index questions and answers and extract knowledge from them
+            return AnswersWikiIntent(question).get_answer()
 
-        raise ex
+        except AskFandomError:
+            # return the original exception
+            raise ex
 
 
 if __name__ == "__main__":

--- a/ask.py
+++ b/ask.py
@@ -7,6 +7,7 @@ import logging
 from os import getenv
 from sys import argv
 
+from ask_fandom.errors import AskFandomError
 from ask_fandom.intents.selector import get_intent
 
 
@@ -15,10 +16,17 @@ def ask_fandom(question: str):
     :type question str
     :rtype: ask_fandom.intents.base.Answer
     """
-    (intent_class, intent_args, _) = get_intent(question)
-    intent = intent_class(question, **intent_args)
+    try:
+        (intent_class, intent_args, _) = get_intent(question)
+        intent = intent_class(question, **intent_args)
 
-    return intent.get_answer()
+        return intent.get_answer()
+
+    except AskFandomError as ex:
+        # fall back to Q&A Wikia site for an answer
+        # TODO: fully index questions and answers and extract knowledge from them
+
+        raise ex
 
 
 if __name__ == "__main__":

--- a/ask_fandom/intents/__init__.py
+++ b/ask_fandom/intents/__init__.py
@@ -7,4 +7,4 @@ Intent encapsulates handling of a specific question type.
 
 # allow intents to be discovered
 from .semantic_media_wiki import EpisodeFactIntent, PersonFactIntent, WoWGroupsMemberIntent
-from .wiki import FootballPlayerFactIntent
+from .wiki import AnswersWikiIntent, FootballPlayerFactIntent

--- a/ask_fandom/intents/wiki/__init__.py
+++ b/ask_fandom/intents/wiki/__init__.py
@@ -2,3 +2,4 @@
 Wiki templates based intents
 """
 from .football import FootballPlayerFactIntent
+from .qa_wiki import AnswersWikiIntent

--- a/ask_fandom/intents/wiki/qa_wiki.py
+++ b/ask_fandom/intents/wiki/qa_wiki.py
@@ -1,0 +1,57 @@
+"""
+Intent handling getting answets from Q&A wikis
+
+https://answers.wikia.com/wiki/What_are_faxes_used_for
+https://answers.wikia.com/wiki/Do_I_need_a_passport_to_travel_to_Italy
+"""
+from .base import AskFandomIntentBase
+
+
+class AnswersWikiIntent(AskFandomIntentBase):
+    """
+    Provides answers using Answers wiki
+    """
+    ANSWER_PHRASE = '{answer}'
+
+    @staticmethod
+    def is_question_supported(words: dict):
+        """
+        Do I need a passport to travel to Italy?
+        What are faxes used for?
+
+        :rtype: bool
+        """
+        return False  # We use this intent as a fallback in ask_fandom function
+
+    @classmethod
+    def get_words_mapping(cls):
+        """
+        Maps intent arguments into word types from the question
+        :rtype: dict
+        """
+        return None
+
+    def _fetch_answer(self):
+        # pylint: disable=fixme
+        # https://answers.wikia.com/wiki/What_are_faxes_used_for
+        answers_wiki = 'answers.wikia.com'
+        page = self.question.rstrip('?')
+
+        site = self.get_mw_client(answers_wiki)
+
+        # http://answers.wikia.com/api.php?action=query&prop=revisions&titles=Do%20I%20need%20a%20passport%20to%20travel%20to%20Italy&rvprop=timestamp%7Cuser%7Ccomment%7Ccontent&rvparse=1&format=json
+        page_object = site.pages[page]
+
+        page_title = page_object.page_title
+        wiki_text = page_object.text()
+
+        self.logger.info('Got the wikitext from <%s>: %s', page_title, wiki_text)
+
+        # take the first line of wikitext
+        answer = wiki_text.split('\n')[0]
+
+        if answer and not answer.startswith('[[Category:'):
+            # TODO: set reference
+            return answer.strip()
+
+        return None

--- a/server.py
+++ b/server.py
@@ -3,24 +3,13 @@ This script runs a web interface of ask-fandom
 """
 import logging
 
+from ask import ask_fandom
 from ask_fandom.intents.base import AskFandomIntentBase
 from ask_fandom.errors import AskFandomError, QuestionNotUnderstoodError
-from ask_fandom.intents.selector import get_intent
 from flask import Flask, jsonify, request, render_template
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
-
-
-def ask_fandom(question: str):
-    """
-    :type question str
-    :rtype: tuple[ask_fandom.intents.base, ask_fandom.intents.base.Answer]
-    """
-    (intent_class, intent_args, words) = get_intent(question)
-    intent = intent_class(question, **intent_args)
-
-    return intent, words, intent.get_answer()
 
 
 def get_example_questions():

--- a/tests/test_get_answer.py
+++ b/tests/test_get_answer.py
@@ -32,7 +32,7 @@ def test_ask_fandom():
     }
 
     for question, expected_answer in test_cases.items():
-        answer = ask_fandom(question)
+        (_, _, answer) = ask_fandom(question)
         print(answer)
         assert str(answer) == expected_answer, question
 

--- a/tests/test_get_answer.py
+++ b/tests/test_get_answer.py
@@ -25,6 +25,10 @@ def test_ask_fandom():
         # normalization
         'who directed The Big Bang episode': '"The Big Bang" episode has been directed by Toby Haynes.',
         'where is Lionel Messi playing now': 'Lionel Messi plays for FC Barcelona now.',
+
+        # fallback to Q&A wiki
+        'Do I need a passport to travel to Italy?':
+            'Yes, you need passport to travel in Italy unless you are the citizen of the Italy.',
     }
 
     for question, expected_answer in test_cases.items():

--- a/tests/test_qa_intent.py
+++ b/tests/test_qa_intent.py
@@ -1,0 +1,18 @@
+"""
+Tests Q&A intent
+"""
+from pytest import raises
+
+from ask_fandom.errors import AnswerNotKnownError
+from ask_fandom.intents import AnswersWikiIntent
+
+
+def test_answers_wiki_intent():
+    assert str(AnswersWikiIntent(question='What are faxes used for?').get_answer()) == \
+           'Faxes are used to send documents from one location to another quickly.'
+
+    answer = AnswersWikiIntent(question='Do I need a passport to travel to Italy?').get_answer()
+    assert answer.answer == 'Yes, you need passport to travel in Italy unless you are the citizen of the Italy.'
+
+    with raises(AnswerNotKnownError):
+        AnswersWikiIntent(question='How can you represent bit information?').get_answer()


### PR DESCRIPTION
Use answers.wikia.com as a fallback when the question is not understood (i.e. no intent is selected) or when selected intent does not know the answer.

This is a temporary solution before we index answer wikis' questions.

## An example

```
INFO:flask.app:Question: Do I need a passport to travel to Italy?
INFO:get_intent:Parsing question: Do I need a passport to travel to Italy?
INFO:get_intent:Parsed and filtered question: [('NP', ''), ('VB', 'need'), ('NP', 'a passport'), ('NN', 'passport'), ('TO', 'to'), ('VB', 'travel'), ('TO', 'to'), ('NP', 'Italy')]
INFO:get_intent:Filtered words of the question: {'NP': 'a passport', 'VB': 'travel', 'NN': 'passport', 'TO': 'to'}
INFO:get_intent:Available intents: ['PersonFactIntent', 'EpisodeFactIntent', 'WoWGroupsMemberIntent', 'FootballPlayerFactIntent', 'AnswersWikiIntent']
INFO:root:Trying PersonFactIntent ...
INFO:root:Trying EpisodeFactIntent ...
INFO:root:Trying WoWGroupsMemberIntent ...
INFO:root:Trying FootballPlayerFactIntent ...
INFO:root:Trying AnswersWikiIntent ...
INFO:AnswersWikiIntent:You've asked: 'Do I need a passport to travel to Italy?' ({})
INFO:AnswersWikiIntent:Got the wikitext from <Do I need a passport to travel to Italy>: Yes, you need passport to travel in Italy unless you are the citizen of the Italy.

[[Category:Travel]]
[[Category:Italy]]
[[Category:Answered questions]]
```

Resolves #12